### PR TITLE
[Refactor][E][B][F] MSA 분리

### DIFF
--- a/backend/app/src/main/java/org/example/backend/matching/event/EvaluationStartRequestedEvent.java
+++ b/backend/app/src/main/java/org/example/backend/matching/event/EvaluationStartRequestedEvent.java
@@ -1,0 +1,24 @@
+package org.example.backend.matching.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EvaluationStartRequestedEvent {
+
+    private String campaignPublicId;
+    private Long benefitIdx;
+
+    @Builder.Default
+    private String eventId = UUID.randomUUID().toString();
+
+    @Builder.Default
+    private long timestamp = System.currentTimeMillis();
+}

--- a/backend/app/src/main/java/org/example/backend/matching/kafka/EvaluationKafkaConsumer.java
+++ b/backend/app/src/main/java/org/example/backend/matching/kafka/EvaluationKafkaConsumer.java
@@ -1,0 +1,40 @@
+package org.example.backend.matching.kafka; // 모놀리식 패키지 경로
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.matching.event.EvaluationStartRequestedEvent;
+import org.example.backend.matching.model.evaluation.EvaluationDto;
+import org.example.backend.matching.service.EvaluationService; // 모놀리식 서비스
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EvaluationKafkaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final EvaluationService evaluationService;
+
+    /**
+     * 📥 평가 모듈이 보낸 질문(식별자 엽서)을 낚아채는 리스너
+     */
+    @KafkaListener(
+            topics = "${app.kafka.topics.evaluation-start:evaluation.start}",
+            groupId = "main-monolithic-group" // 모놀리식 전용 그룹 ID
+    )
+    public void consumeEvaluationQuery(String message) {
+        log.info("[Monolithic] 평가 모듈로부터 요청 접수 (Raw Payload): {}", message);
+        try {
+            // String으로 받아서 역직렬화하는 것이 패키지 불일치 에러를 피하기 가장 안전합니다.
+            EvaluationStartRequestedEvent queryEvent =
+                    objectMapper.readValue(message, EvaluationStartRequestedEvent.class);
+            // Step 3에서 만들 비즈니스 로직 메서드 호출
+            evaluationService.startEvaluation(EvaluationDto.StartEvaluationReq.from(queryEvent));
+
+        } catch (Exception e) {
+            log.error("[Monolithic] 요청 처리 중 에러 발생: ", e);
+        }
+    }
+}

--- a/backend/app/src/main/java/org/example/backend/matching/kafka/EvaluationKafkaProducer.java
+++ b/backend/app/src/main/java/org/example/backend/matching/kafka/EvaluationKafkaProducer.java
@@ -3,11 +3,13 @@ package org.example.backend.matching.kafka;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.backend.matching.model.evaluation.EvaluationDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class EvaluationKafkaProducer {
@@ -21,8 +23,15 @@ public class EvaluationKafkaProducer {
     @Value("${app.kafka.topics.evaluation-collect}")
     private String evaluationCollectTopic;
 
-    public void startEvaluation(EvaluationDto.StartEvaluation request) {
-        send(evaluationStartTopic, request.getCampaignIdx(), request);
+    // 💡 수정: 모듈의 요청에 '답변'을 줄 토픽 경로로 바꿉니다.
+    @Value("${app.kafka.topics.evaluation-start-reply:evaluation.start-reply}")
+    private String evaluationStartReplyTopic;
+
+    public void sendStartReply(EvaluationDto.StartEvaluation request) {
+        // 답변을 보낼 때는 campaignIdx(publicId)를 메시지 키로 사용
+        log.info("[Evaluation MSA] start request sending. benefitIdx={}, campaignIdx={}",
+                request.getBenefit().getIdx(), request.getCampaign().idx());
+        send(evaluationStartReplyTopic, request.getCampaignIdx(), request);
     }
 
     public void collect(EvaluationDto.CollectDto request) {

--- a/backend/app/src/main/java/org/example/backend/matching/model/evaluation/EvaluationDto.java
+++ b/backend/app/src/main/java/org/example/backend/matching/model/evaluation/EvaluationDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.*;
 import org.example.backend.campaign.model.Campaign;
 import org.example.backend.campaign.model.CampaignDto;
+import org.example.backend.matching.event.EvaluationStartRequestedEvent;
 import org.example.backend.matching.model.*;
 import org.example.backend.organization.model.Organization;
 
@@ -183,6 +184,10 @@ public class EvaluationDto {
     @Builder
     public static class StartEvaluationReq {
         private Long benefitIdx;
+        private String publicId;
+        public static StartEvaluationReq from(EvaluationStartRequestedEvent event) {
+            return StartEvaluationReq.builder().benefitIdx(event.getBenefitIdx()).publicId(event.getCampaignPublicId()).build();
+        }
     }
 
     @Getter

--- a/backend/app/src/main/java/org/example/backend/matching/service/EvaluationService.java
+++ b/backend/app/src/main/java/org/example/backend/matching/service/EvaluationService.java
@@ -7,6 +7,7 @@ import org.example.backend.campaign.model.Campaign;
 import org.example.backend.campaign.model.CampaignDto;
 import org.example.backend.campaign.repository.CampaignRepository;
 import org.example.backend.matching.client.MatchingEvaluationClient;
+import org.example.backend.matching.event.EvaluationStartRequestedEvent;
 import org.example.backend.matching.kafka.EvaluationKafkaProducer;
 import org.example.backend.matching.model.MatchingDto;
 import org.example.backend.matching.model.PartnerBenefits;
@@ -34,7 +35,7 @@ public class EvaluationService {
                         "해당 Benefit을 찾을 수 없습니다. Benefit ID: " + dto.getBenefitIdx()
                 ));
 
-        Campaign campaign = campaignRepository.findById(benefit.getCampaign().getIdx())
+        Campaign campaign = campaignRepository.findByPublicId(dto.getPublicId())
                 .orElseThrow(() -> new EntityNotFoundException(
                         "해당 Campaign을 찾을 수 없습니다. Campaign ID: " + benefit.getCampaign().getIdx()
                 ));
@@ -48,7 +49,7 @@ public class EvaluationService {
         log.info("[Evaluation MSA] start request forwarded. benefitIdx={}, campaignIdx={}",
                 benefit.getIdx(), campaign.getIdx());
 
-        evaluationKafkaProducer.startEvaluation(request);
+        evaluationKafkaProducer.sendStartReply(request);
     }
 
     public void collect(EvaluationDto.CollectDto dto) {
@@ -68,5 +69,8 @@ public class EvaluationService {
                 publicId, campaign.getIdx());
 
         return matchingEvaluationClient.getResult(campaign.getPublicId());
+    }
+
+    public void processAndReplyEvaluation(EvaluationStartRequestedEvent queryEvent) {
     }
 }

--- a/backend/app/src/main/java/org/example/backend/matching/service/EvaluationService.java
+++ b/backend/app/src/main/java/org/example/backend/matching/service/EvaluationService.java
@@ -13,6 +13,7 @@ import org.example.backend.matching.model.PartnerBenefits;
 import org.example.backend.matching.model.evaluation.EvaluationDto;
 import org.example.backend.matching.repository.BenefitRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -26,6 +27,7 @@ public class EvaluationService {
     private final EvaluationKafkaProducer evaluationKafkaProducer;
     private final MatchingEvaluationClient matchingEvaluationClient;
 
+    @Transactional(readOnly = true)
     public void startEvaluation(EvaluationDto.StartEvaluationReq dto) {
         PartnerBenefits benefit = benefitRepository.findById(dto.getBenefitIdx())
                 .orElseThrow(() -> new EntityNotFoundException(

--- a/backend/app/src/main/resources/application-dev.yml
+++ b/backend/app/src/main/resources/application-dev.yml
@@ -24,6 +24,9 @@ app:
     topics:
       evaluation-start: evaluation.start
       evaluation-collect: evaluation.collect
+    consumer:
+      propoerties:
+        spring.json.use.type.headers: false
 msa:
   matching-evaluation:
     base-url: ${EVALUATION_URL}
@@ -99,6 +102,8 @@ spring:
 
   kafka:
     bootstrap-servers: localhost:9092
+    topics:
+      evaluation-start: evaluation-start
 
 logging:
   level:

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/common/model/BaseResponseStatus.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/common/model/BaseResponseStatus.java
@@ -17,7 +17,7 @@ public enum BaseResponseStatus {
 
     // 3000번대 클라이언트 입력 오류, 입력값 검증 오류
     VALIDATION_ERROR(false, 3005, "입력값을 확인해주세요."),
-
+    EMPTY_PAYLOAD(false, 3006 ,"입력값이 비었습니다." ),
 
     // 5000번대 실패
     FAIL(false, 5000, "요청이 실패했습니다."),

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/controller/EvaluationController.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/controller/EvaluationController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.evaluation.common.model.BaseResponse;
 import org.example.evaluation.common.model.BaseResponseStatus;
 import org.example.evaluation.model.EvaluationDto;
+import org.example.evaluation.model.N8nEvaluationPayloadDto;
 import org.example.evaluation.service.EvaluationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,9 +36,14 @@ public class EvaluationController {
     }
 
     @PostMapping("/collect")
-    public ResponseEntity<BaseResponse> collect(@RequestBody EvaluationDto.SaveEvaluationReq dto) {
+    public ResponseEntity<BaseResponse> collect(@RequestBody N8nEvaluationPayloadDto dto) {
+
+        if (dto == null) {
+            return ResponseEntity.badRequest().body(BaseResponse.fail(BaseResponseStatus.EMPTY_PAYLOAD));
+        }
+
         try {
-            evaluationService.requestCollectEvaluation(dto);
+            evaluationService.collect(dto);
             return ResponseEntity.accepted()
                     .body(BaseResponse.processing(BaseResponseStatus.SUCCESSFULY_EVALUATED));
         } catch (Exception e) {

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/event/EvaluationStartRequestedEvent.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/event/EvaluationStartRequestedEvent.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.example.evaluation.model.EvaluationDto;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @Builder
@@ -17,21 +19,12 @@ import org.example.evaluation.model.EvaluationDto;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EvaluationStartRequestedEvent {
 
-    @JsonAlias({"campaignIdx", "campaignPublicId"})
     private String campaignPublicId;
+    private Long benefitIdx;
 
-    private Object campaign;
-    private Object benefit;
+    @Builder.Default
+    private String eventId = UUID.randomUUID().toString();
 
-    public String key() {
-        return campaignPublicId;
-    }
-
-    public EvaluationDto.StartEvaluationReq toServiceRequest() {
-        return EvaluationDto.StartEvaluationReq.builder()
-                .campaignIdx(campaignPublicId)
-                .campaign(campaign)
-                .benefit(benefit)
-                .build();
-    }
+    @Builder.Default
+    private long timestamp = System.currentTimeMillis();
 }

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
@@ -6,8 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.evaluation.event.EvaluationCompletedEvent;
 import org.example.evaluation.event.EvaluationCollectRequestedEvent;
-import org.example.evaluation.event.EvaluationFailedEvent;
-import org.example.evaluation.event.EvaluationStartRequestedEvent;
 import org.example.evaluation.model.EvaluationDocument;
 import org.example.evaluation.model.EvaluationDto;
 import org.example.evaluation.service.EvaluationService;
@@ -23,21 +21,25 @@ public class EvaluationKafkaConsumer {
     private final EvaluationService evaluationService;
     private final EvaluationKafkaProducer evaluationKafkaProducer;
 
+    /**
+     * ⭐️ 메인 모듈(모놀리식)이 꽉 채워 보내준 데이터 스냅샷을 수신하는 리스너
+     * 오직 모놀리식의 '응답 토픽'만 구독해야 합니다.
+     */
     @KafkaListener(
-            topics = "${app.kafka.topics.evaluation-start}",
+            topics = "${app.kafka.topics.evaluation-start-reply:evaluation.start-reply}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    @KafkaListener(topics = "campaign-response-topic", groupId = "evaluation-module-group")
     public void consumeMainModuleResponse(EvaluationDto.StartEvaluation response) {
         log.info("[Evaluation MSA] 메인 모듈로부터 데이터 스냅샷 수신 완료. campaignIdx(publicId)={}",
                 response.getCampaignIdx());
 
-        // 2. 수신한 꽉 찬 데이터를 가지고 n8n 웰훅을 찌르거나 파이프라인 가동!
-        // 기존 startEvaluation(EvaluationDto.StartEvaluationReq dto)을
-        // 넘겨받은 상세 데이터에 맞게 가공하여 오버로딩 혹은 수정해서 호출하시면 됩니다.
+        // 수신한 데이터를 가지고 n8n 웹훅을 호출하는 비즈니스 로직 가동
         evaluationService.startEvaluation(response);
     }
 
+    /**
+     * n8n 연산 완료 후 결과 수집을 위한 기존 리스너 (기존 코드 유지)
+     */
     @KafkaListener(
             topics = "${app.kafka.topics.evaluation-collect}",
             groupId = "${spring.kafka.consumer.group-id}"

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
@@ -23,18 +23,32 @@ public class EvaluationKafkaConsumer {
 
     /**
      * ⭐️ 메인 모듈(모놀리식)이 꽉 채워 보내준 데이터 스냅샷을 수신하는 리스너
-     * 오직 모놀리식의 '응답 토픽'만 구독해야 합니다.
+     * String으로 안전하게 받아와 ObjectMapper를 통해 객체로 변환합니다.
      */
     @KafkaListener(
             topics = "${app.kafka.topics.evaluation-start-reply:evaluation.start-reply}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void consumeMainModuleResponse(EvaluationDto.StartEvaluation response) {
-        log.info("[Evaluation MSA] 메인 모듈로부터 데이터 스냅샷 수신 완료. campaignIdx(publicId)={}",
-                response.getCampaignIdx());
+    public void consumeMainModuleResponse(String message) { // 💡 EvaluationDto.StartEvaluation에서 String으로 변경
+        log.info("[Evaluation MSA] 메인 모듈로부터 응답 수신 (Raw Payload): {}", message);
 
-        // 수신한 데이터를 가지고 n8n 웹훅을 호출하는 비즈니스 로직 가동
-        evaluationService.startEvaluation(response);
+        try {
+            // 💡 명시적으로 Json 문자열을 수신 측 DTO 객체로 변환
+            EvaluationDto.StartEvaluation response =
+                    objectMapper.readValue(message, EvaluationDto.StartEvaluation.class);
+
+            log.info("[Evaluation MSA] 메인 모듈로부터 데이터 스냅샷 수신 및 파싱 완료. campaignIdx(publicId)={}",
+                    response.getCampaignIdx());
+
+            // 수신한 데이터를 가지고 n8n 웹훅을 호출하는 비즈니스 로직 가동
+            evaluationService.startEvaluation(response);
+
+        } catch (JsonProcessingException e) {
+            log.error("[Evaluation MSA] 응답 메시지 역직렬화(JSON 파싱) 실패. message={}", message, e);
+            // 필요 시 에러 핸들링 파이프라인 전송 가능 (예: sendStartDeadLetter)
+        } catch (RuntimeException e) {
+            log.error("[Evaluation MSA] 응답 처리 중 비즈니스 로직 에러 발생", e);
+        }
     }
 
     /**

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaConsumer.java
@@ -9,6 +9,7 @@ import org.example.evaluation.event.EvaluationCollectRequestedEvent;
 import org.example.evaluation.event.EvaluationFailedEvent;
 import org.example.evaluation.event.EvaluationStartRequestedEvent;
 import org.example.evaluation.model.EvaluationDocument;
+import org.example.evaluation.model.EvaluationDto;
 import org.example.evaluation.service.EvaluationService;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -26,25 +27,15 @@ public class EvaluationKafkaConsumer {
             topics = "${app.kafka.topics.evaluation-start}",
             groupId = "${spring.kafka.consumer.group-id}"
     )
-    public void consumeStartEvaluation(String message) {
-        log.info("[Kafka] evaluation.start received: {}", message);
+    @KafkaListener(topics = "campaign-response-topic", groupId = "evaluation-module-group")
+    public void consumeMainModuleResponse(EvaluationDto.StartEvaluation response) {
+        log.info("[Evaluation MSA] 메인 모듈로부터 데이터 스냅샷 수신 완료. campaignIdx(publicId)={}",
+                response.getCampaignIdx());
 
-        EvaluationStartRequestedEvent event = null;
-        try {
-            event = objectMapper.readValue(message, EvaluationStartRequestedEvent.class);
-
-            evaluationService.startEvaluation(event.toServiceRequest());
-        } catch (JsonProcessingException e) {
-            log.error("[Kafka] evaluation.start deserialize failed.", e);
-            evaluationKafkaProducer.sendStartDeadLetter(null, message, e.getMessage());
-        } catch (RuntimeException e) {
-            log.error("[Kafka] evaluation.start processing failed.", e);
-            evaluationKafkaProducer.sendFailed(EvaluationFailedEvent.builder()
-                    .campaignPublicId(event != null ? event.getCampaignPublicId() : null)
-                    .failedStage("N8N_WEBHOOK")
-                    .reason(e.getMessage())
-                    .build());
-        }
+        // 2. 수신한 꽉 찬 데이터를 가지고 n8n 웰훅을 찌르거나 파이프라인 가동!
+        // 기존 startEvaluation(EvaluationDto.StartEvaluationReq dto)을
+        // 넘겨받은 상세 데이터에 맞게 가공하여 오버로딩 혹은 수정해서 호출하시면 됩니다.
+        evaluationService.startEvaluation(response);
     }
 
     @KafkaListener(

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaProducer.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaProducer.java
@@ -38,9 +38,9 @@ public class EvaluationKafkaProducer {
     @Value("${app.kafka.topics.evaluation-collect-dlq:evaluation.collect.dlq}")
     private String evaluationCollectDlqTopic;
 
-//    public void sendStart(EvaluationStartRequestedEvent event) {
-//        send(evaluationStartTopic, event.key(), event);
-//    }
+    public void sendStart(EvaluationStartRequestedEvent event) {
+        send(evaluationStartTopic, event.getCampaignPublicId(), event);
+    }
 
     public void sendCollect(EvaluationCollectRequestedEvent event) {
         send(evaluationCollectTopic, event.key(), event);

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaProducer.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/kafka/EvaluationKafkaProducer.java
@@ -38,9 +38,9 @@ public class EvaluationKafkaProducer {
     @Value("${app.kafka.topics.evaluation-collect-dlq:evaluation.collect.dlq}")
     private String evaluationCollectDlqTopic;
 
-    public void sendStart(EvaluationStartRequestedEvent event) {
-        send(evaluationStartTopic, event.key(), event);
-    }
+//    public void sendStart(EvaluationStartRequestedEvent event) {
+//        send(evaluationStartTopic, event.key(), event);
+//    }
 
     public void sendCollect(EvaluationCollectRequestedEvent event) {
         send(evaluationCollectTopic, event.key(), event);

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/model/EvaluationDto.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/model/EvaluationDto.java
@@ -40,17 +40,6 @@ public class EvaluationDto {
         }
     }
 
-//    @Getter
-//    @Setter
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    @Builder
-//    public static class StartEvaluationReq {
-//        private String campaignIdx;
-//        private Object campaign;
-//        private Object benefit;
-//    }
-
     @Getter
     @Setter
     @NoArgsConstructor

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/model/EvaluationDto.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/model/EvaluationDto.java
@@ -3,7 +3,10 @@ package org.example.evaluation.model;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
 
 public class EvaluationDto {
 
@@ -37,15 +40,25 @@ public class EvaluationDto {
         }
     }
 
+//    @Getter
+//    @Setter
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    @Builder
+//    public static class StartEvaluationReq {
+//        private String campaignIdx;
+//        private Object campaign;
+//        private Object benefit;
+//    }
+
     @Getter
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     public static class StartEvaluationReq {
+        private Long benefitIdx;
         private String campaignIdx;
-        private Object campaign;
-        private Object benefit;
     }
 
     @Getter
@@ -81,5 +94,114 @@ public class EvaluationDto {
                     .evaluations(evaluations)
                     .build();
         }
+    }
+
+    // kafka용 Dto
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class StartEvaluation {
+        private String campaignIdx; // 내용물은 String publicId
+        private CampaignRes campaign; // Object 대신 정석대로 정적 타입 매핑
+        private BenefitRes benefit;   // 모놀리식의 Benefit 스펙 매핑
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class CampaignRes {
+        private String id;
+        private Long idx;
+        private String name;
+        private String purpose;
+        private List<String> tags;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private String period;
+        private List<String> partners;
+        private String goals;
+        private String assetName;
+        private String assetDescription;
+        private String primaryGoal;
+        private List<String> campaignMethods;
+        private String maxCost;
+        private String minRevenue;
+        private String status;
+        private String initials;
+        private String icon;
+        private String color;
+        private Date createdAt;
+        private Date updatedAt;
+
+        // 💡 의존성 제거를 위해 String으로 안전하게 수신합니다.
+        private String myCampaignRole;
+        private boolean organizationIsPm;
+        private Integer totalTaskCount;
+    }
+
+    /**
+     * ⭐️ 모놀리식의 Benefit 클래스 스펙과 1:1 매핑되는 클래스
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class BenefitRes {
+        private Long idx;
+        private String affiliate;
+        private Long campaignIdx;
+
+        // [기본 정보]
+        private String name;
+        private String type;
+        private String description;
+
+        // [규모·재고]
+        private Long quantity;
+        private String quantityUnit;
+        private Long valuePerPerson;
+        private Long totalValue;
+
+        // [기간]
+        private LocalDate periodStart;
+        private LocalDate periodEnd;
+        private Boolean alwaysNegotiable;
+        private Integer prepDays;
+
+        // [대상]
+        private String targetAudience;
+        private Long expectedReach;
+
+        // [비용 부담]
+        private String costBearer;
+        private Integer costPartnerPercent;
+        private Integer costOursPercent;
+        private String costDetails;
+
+        // [운영 조건]
+        private String exposureChannels;
+        private String requiredCollaborations;
+        private String conditions;
+
+        // [연결 자산]
+        private String desiredAssets;
+        private Boolean autoRecommend;
+
+        // [담당자]
+        private String managerName;
+        private String managerEmail;
+        private String managerPhone;
+
+        // 상태 및 생성일
+        private String status;
+        private LocalDateTime createdAt;
     }
 }

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/model/N8nEvaluationPayloadDto.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/model/N8nEvaluationPayloadDto.java
@@ -13,6 +13,7 @@ public class N8nEvaluationPayloadDto {
 
     // 공통 메타 데이터 [cite: 1, 6, 11, 16, 21]
     private String uuid;
+    private String publicId;
     private Long campaignIdx;
     private Long benefitIdx;
     private String category;

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/model/N8nEvaluationPayloadDto.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/model/N8nEvaluationPayloadDto.java
@@ -1,0 +1,59 @@
+package org.example.evaluation.model;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class N8nEvaluationPayloadDto {
+
+    // 공통 메타 데이터 [cite: 1, 6, 11, 16, 21]
+    private String uuid;
+    private Long campaignIdx;
+    private Long benefitIdx;
+    private String category;
+    private Integer overallScore;
+    private List<String> improvementDirections;
+
+    // BRAND 영역 필드 [cite: 1]
+    private String brandTone;
+    private String priceRange;
+    private String customerExperience;
+    private String brandTrust;
+    private String reputationRisk;
+    private String hanwhaImageConsistency;
+
+    // COST 영역 필드 [cite: 6]
+    private String partnerSampleScale;
+    private String partnerDiscountCostBurden;
+    private String coProductionCostSharing;
+    private String hanwhaDirectCostBurden;
+    private String existingHanwhaChannelUtilization;
+
+    // CUSTOMER 영역 필드 [cite: 11]
+    private String customerAgeGroup;
+    private String customerSpendingPatterns;
+    private String membershipTier;
+    private String usageChannel;
+    private String benefitCategory;
+
+    // OPERATION 영역 필드 [cite: 16]
+    private String approvalStepsCount;
+    private String legalReviewRequired;
+    private String brandReviewRequired;
+    private String deliverablesCount;
+    private String participatingDeptsAndPartners;
+    private String scheduleUrgency;
+    private String offlineOrOnsiteStaffRequired;
+
+    // REVENUE 영역 필드 [cite: 21]
+    private String purchaseConversionProbability;
+    private String roomReservationIncreaseProbability;
+    private String appRegistrationIncreaseProbability;
+    private String membershipRegistrationRevisitProbability;
+    private String alignmentwithCampaignGoalsandKPIs;
+}

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
@@ -12,8 +12,13 @@ import org.example.evaluation.event.EvaluationStartRequestedEvent;
 import org.example.evaluation.kafka.EvaluationKafkaProducer;
 import org.example.evaluation.model.EvaluationDocument;
 import org.example.evaluation.model.EvaluationDto;
+import org.example.evaluation.model.N8nEvaluationPayloadDto;
 import org.example.evaluation.repository.EvaluationMongoRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -126,5 +131,92 @@ public class EvaluationService {
         return documents.stream()
                 .map(EvaluationDto.MongoEvaluationRes::of)
                 .collect(Collectors.toList());
+    }
+    private final MongoTemplate mongoTemplate;
+    public void collect(N8nEvaluationPayloadDto payload) {
+        Query query = new Query(Criteria.where("sessionId").is(payload.getUuid()));
+        Update update = new Update();
+        // 2. 공통 기본 인프라 정보 업데이트 설정
+        update.set("publicId", String.valueOf(payload.getCampaignIdx()));
+
+        // 3. 카테고리별 분기 및 객체 바인딩 수행 [cite: 5, 10, 20]
+        String category = payload.getCategory().toUpperCase();
+        switch (category) {
+            case "BRAND":
+                EvaluationDocument.Brand brand = EvaluationDocument.Brand.builder()
+                        .overallScore(payload.getOverallScore())
+                        .improvementDirections(payload.getImprovementDirections())
+                        .brandTone(payload.getBrandTone())
+                        .priceRange(payload.getPriceRange())
+                        .customerExperience(payload.getCustomerExperience())
+                        .brandTrust(payload.getBrandTrust())
+                        .reputationRisk(payload.getReputationRisk())
+                        .hanwhaImageConsistency(payload.getHanwhaImageConsistency())
+                        .build();
+                update.set("evaluations.brand", brand);
+                break;
+
+            case "COST":
+                EvaluationDocument.Cost cost = EvaluationDocument.Cost.builder()
+                        .overallScore(payload.getOverallScore())
+                        .improvementDirections(payload.getImprovementDirections())
+                        .partnerSampleScale(payload.getPartnerSampleScale())
+                        .partnerDiscountCostBurden(payload.getPartnerDiscountCostBurden())
+                        .coProductionCostSharing(payload.getCoProductionCostSharing())
+                        .hanwhaDirectCostBurden(payload.getHanwhaDirectCostBurden())
+                        .existingHanwhaChannelUtilization(payload.getExistingHanwhaChannelUtilization())
+                        .build();
+                update.set("evaluations.cost", cost);
+                break;
+
+            case "CUSTOMER":
+                EvaluationDocument.Customer customer = EvaluationDocument.Customer.builder()
+                        .overallScore(payload.getOverallScore())
+                        .improvementDirections(payload.getImprovementDirections())
+                        .customerAgeGroup(payload.getCustomerAgeGroup())
+                        .customerSpendingPatterns(payload.getCustomerSpendingPatterns())
+                        .membershipTier(payload.getMembershipTier())
+                        .usageChannel(payload.getUsageChannel())
+                        .benefitCategory(payload.getBenefitCategory())
+                        .build();
+                update.set("evaluations.customer", customer);
+                break;
+
+            case "OPERATION":
+                EvaluationDocument.Operation operation = EvaluationDocument.Operation.builder()
+                        .overallScore(payload.getOverallScore())
+                        .improvementDirections(payload.getImprovementDirections())
+                        .approvalStepsCount(payload.getApprovalStepsCount())
+                        .legalReviewRequired(payload.getLegalReviewRequired())
+                        .brandReviewRequired(payload.getBrandReviewRequired())
+                        .deliverablesCount(payload.getDeliverablesCount())
+                        .participatingDeptsAndPartners(payload.getParticipatingDeptsAndPartners())
+                        .scheduleUrgency(payload.getScheduleUrgency())
+                        .offlineOrOnsiteStaffRequired(payload.getOfflineOrOnsiteStaffRequired())
+                        .build();
+                update.set("evaluations.operation", operation);
+                break;
+
+            case "REVENUE":
+                EvaluationDocument.Revenue revenue = EvaluationDocument.Revenue.builder()
+                        .overallScore(payload.getOverallScore())
+                        .improvementDirections(payload.getImprovementDirections())
+                        .purchaseConversionProbability(payload.getPurchaseConversionProbability())
+                        .roomReservationIncreaseProbability(payload.getRoomReservationIncreaseProbability())
+                        .appRegistrationIncreaseProbability(payload.getAppRegistrationIncreaseProbability())
+                        .membershipRegistrationRevisitProbability(payload.getMembershipRegistrationRevisitProbability())
+                        .alignmentwithCampaignGoalsandKPIs(payload.getAlignmentwithCampaignGoalsandKPIs())
+                        .build();
+                update.set("evaluations.revenue", revenue);
+                break;
+
+            default:
+                log.error("Unknown evaluation category type: {}", category);
+                throw new IllegalArgumentException("Unknown evaluation category type: " + category);
+        }
+
+        // 4. 원자적 Upsert 실행 (@EnableMongoAuditing이 적용되어 있다면 내부적으로 startedAt/endedAt도 제어됨)
+        mongoTemplate.upsert(query, update, EvaluationDocument.class);
+        log.info("Successfully upserted data to MongoDB for sessionId: {}", payload.getUuid());
     }
 }

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
@@ -50,7 +50,7 @@ public class EvaluationService {
         log.info("[Evaluation MSA] 메인 모듈에 데이터 조회 요청 전송. publicId={}, benefitIdx={}",
                 dto.getCampaignIdx(), dto.getBenefitIdx());
 
-//        evaluationKafkaProducer.sendStart(event);
+        evaluationKafkaProducer.sendStart(event);
     }
 
     public void requestCollectEvaluation(EvaluationDto.SaveEvaluationReq dto) {

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
@@ -31,14 +31,26 @@ public class EvaluationService {
     @Value("${custom.n8n.webhook-url}${custom.n8n.evaluation-endpoint}")
     private String n8nWebhookUrl;
 
+//    public void requestStartEvaluation(EvaluationDto.StartEvaluationReq dto) {
+//        EvaluationStartRequestedEvent event = EvaluationStartRequestedEvent.builder()
+//                .campaignPublicId(dto.getCampaignIdx())
+//                .campaign(dto.getCampaign())
+//                .benefit(dto.getBenefit())
+//                .build();
+//
+//        evaluationKafkaProducer.sendStart(event);
+//    }
+
     public void requestStartEvaluation(EvaluationDto.StartEvaluationReq dto) {
         EvaluationStartRequestedEvent event = EvaluationStartRequestedEvent.builder()
                 .campaignPublicId(dto.getCampaignIdx())
-                .campaign(dto.getCampaign())
-                .benefit(dto.getBenefit())
+                .benefitIdx(dto.getBenefitIdx())
                 .build();
 
-        evaluationKafkaProducer.sendStart(event);
+        log.info("[Evaluation MSA] 메인 모듈에 데이터 조회 요청 전송. publicId={}, benefitIdx={}",
+                dto.getCampaignIdx(), dto.getBenefitIdx());
+
+//        evaluationKafkaProducer.sendStart(event);
     }
 
     public void requestCollectEvaluation(EvaluationDto.SaveEvaluationReq dto) {
@@ -57,7 +69,7 @@ public class EvaluationService {
         evaluationKafkaProducer.sendCollect(event);
     }
 
-    public void startEvaluation(EvaluationDto.StartEvaluationReq dto) {
+    public void startEvaluation(EvaluationDto.StartEvaluation dto) {
         try {
             restClient.post()
                     .uri(n8nWebhookUrl)

--- a/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
+++ b/backend/matching-evaluation/src/main/java/org/example/evaluation/service/EvaluationService.java
@@ -137,7 +137,7 @@ public class EvaluationService {
         Query query = new Query(Criteria.where("sessionId").is(payload.getUuid()));
         Update update = new Update();
         // 2. 공통 기본 인프라 정보 업데이트 설정
-        update.set("publicId", String.valueOf(payload.getCampaignIdx()));
+        update.set("publicId", String.valueOf(payload.getPublicId()));
 
         // 3. 카테고리별 분기 및 객체 바인딩 수행 [cite: 5, 10, 20]
         String category = payload.getCategory().toUpperCase();

--- a/frontend/src/components/matchengine/EvaluationModal.vue
+++ b/frontend/src/components/matchengine/EvaluationModal.vue
@@ -49,8 +49,8 @@ function submitRequest() {
 
   // 평가 요청에 필요한 정보 담기
   const submit = {
-    campaign: props.campaignInfo,
-    benefit: selectedBenefit.value,
+    // campaign: props.campaignInfo,
+    benefitIdx: selectedBenefit.value.idx,
   }
 
   // console.log(submit)

--- a/frontend/src/views/MatchOverview.vue
+++ b/frontend/src/views/MatchOverview.vue
@@ -66,8 +66,6 @@ function moveToMatchingTab(criteria) {
 
 function requestEvaluation(candidate) {
   evaluationCandidate.value = candidate ?? null
-  console.log(candidate)
-  console.log("ㅎㅇ")
   startEvaluation(evaluationCandidate.value);
   currentTab.value = 'evaluation'
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,6 +22,7 @@ export default defineConfig({
     },
   },
   server: {
+    host:'0.0.0.0',
     proxy: {
       // 경로가 /api로 시작하는 요청을 대상으로 함
       '/api': {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -30,14 +30,6 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/api/, ''), // 요청 경로에서 /api를 제거하고 전달
         secure: false,                  // SSL 인증서 검증 무시 (자체 서명된 인증서 사용 시 필요)
       },
-
-      // matching-evaluation 모듈로 가는 요청
-      '/matching-evaluation-api': {
-        target: 'http://localhost:8082',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/matching-evaluation-api/, ''),
-        secure: false,
-      },
     },
   },
 })


### PR DESCRIPTION
전체 구조 재구성
프론트 평가 요청 -> 평가 모듈 -> Kafka -> 모놀리식 -> kafka -> 평가 모듈 -> n8n -> 평가 모듈 -> MongoDB

프론트에서 주는 데이터를 기존 API 명세로 복원 (Campaign, Benefit 두개의 클래스 -> publicId, benefitIdx 두개의 파라미터)
두개의 구분자를 통해 카프카에게 데이터 요청